### PR TITLE
Scissor operator to conduction band 

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,6 +133,8 @@ There are 5 Namelists in the ~input.nml~ file: ~allocations~, ~crystal_info~, ~e
 | ~indlowconduction~ | Integer                      |             0 | Lowest conduction band index. For ~metallic~ .False., this or ~indhighvalence~ must be provided.                                                                          |
 | ~indhighvalence~   | Integer                      |             0 | Highest valence band index. For ~metallic~ .False., this or ~indlowconduction~ must be provided.                                                                          |
 | ~dopingtype~       | Character                    |           'x' | Type of doping ('n' or 'p'). This is needed for ~runlevel~ 0 only. See table of keys for Namelist 'numerics'.                                                             |
+| ~scissor~          | Real                         |          0.0  | Scissor operator for conduction bands in eV.
+|
 | ~numconc~          | Integer                      |           100 | Number of carrier concentration points. This is needed for ~runlevel~ 0 only. See table of keys for Namelist 'numerics'.                                                  |
 | ~conclist~         | Real array of size ~numconc~ |           0.0 | List carrier concentrations in cm^{-3} (or cm^{-2} if ~twod~ is .True.). This is needed for ~runlevel~ 0 only. See table of keys for Namelist 'numerics'.                 |
 | ~numT~             | Integer                      |           100 | Number of temperature points. This is needed for ~runlevel~ 0 only. See table of keys for Namelist 'numerics'.                                                            |

--- a/app/elphbolt.f90
+++ b/app/elphbolt.f90
@@ -117,7 +117,7 @@ program elphbolt
         call subtitle("Plotting along high-symmetry path...")
 
         !Plot electron bands, phonon dispersions, and g along path.
-        call wann%plot_along_path(crys, num)
+        call wann%plot_along_path(crys, num, el%scissor)
 
         call t_event%end_timer('Plots along path')
      end if

--- a/test/bte_regression.f90
+++ b/test/bte_regression.f90
@@ -215,7 +215,7 @@ program bte_regression
      call subtitle("Plotting along high-symmetry path...")
 
      !Plot electron bands, phonon dispersions, and g along path.
-     call wann%plot_along_path(crys, num)
+     call wann%plot_along_path(crys, num,el%scissor)
 
      call t_event%end_timer('Plots along path')
   end if


### PR DESCRIPTION
Added scissor operator to conduction band, for cases in which such a correction might be essential, like Ge. Tested against test case (Si) but with n-doping (log files attached). The used scissor operator for this case was that necessary for gap to match that of Varshni's model [Y. Varshni, Physica 34, 149 (1967)] for Si at 300 K.
[noscissor.log](https://github.com/nakib/elphbolt/files/10723828/noscissor.log)
[scissor.log](https://github.com/nakib/elphbolt/files/10723829/scissor.log)
