### PR TITLE
Addition of isotopic and echimp terms to the iterative procedure

### DIFF
--- a/src/phonon.f90
+++ b/src/phonon.f90
@@ -35,6 +35,18 @@ module phonon_module
   private
   public phonon
   
+
+  !! Type for isotopic scattering (each image will contain its own block)
+  type massvar_information
+       !! Information about phonons
+       integer(i64), allocatable      :: index1(:)
+       integer(i64), allocatable      :: index2(:)
+       ! Matrix elements for isotopic processes in given proc
+       real(r64), allocatable :: Gamma_massvar(:)
+       !! Number of isotopic processes in given proc
+       integer :: nstates = 0
+  end type massvar_information
+
   type, extends(particle) :: phonon
      !! Data and procedures related to phonons.
      
@@ -60,6 +72,10 @@ module phonon_module
      !Data read from ifc2 file. These will be used in the phonon calculation.
      real(r64) :: rws(124, 0:3), cell_r(1:3, 0:3), cell_g(1:3, 0:3)
      real(r64), allocatable :: mm(:,:), rr(:,:,:)
+     
+
+     !Data for isotopic and substituional variables
+     type(massvar_information) :: phiso, phsubs
       
    contains
 


### PR DESCRIPTION
Dear Nakib,

I've also added the isotopic contribution to the iterative procedure (see last term of the Eq. 6 of the ShenBTE paper and the code last version in which I've added such terms within the iterative procedure). The transition rates required are saved in memory by each proc, though it might be not a good option for dense meshes.

Similarly, I've added the echimp contribution to the iterative procedure.
I attach the test on Si (using this time the minimal mesh), the RTA is equal in both cases, whereas iterative solutions have small differences (something expected, for reference Si in ShengBTE with and without the iterative procedure has a relative difference of 0.0001).

[new.log](https://github.com/nakib/elphbolt/files/10724704/new.log)
[old.log](https://github.com/nakib/elphbolt/files/10724705/old.log)

Best regards, 

Martí
