### PR TITLE
Interpolation routines and iterative cycle

### DIFF
--- a/src/bte.f90
+++ b/src/bte.f90
@@ -372,7 +372,7 @@ contains
        allocate(widc(product(el%wvmesh),6), idc(product(el%wvmesh),9), &
                 ksint(product(el%wvmesh),3))
        do ik = 1, size(ksint,1)
-           call demux_vector(ik, ksint(ik,:), el%wvmesh, 0_k8)
+           call demux_vector(ik, ksint(ik,:), el%wvmesh, 0_i64)
        end do
        call precompute_interpolation_corners_and_weights(ph%wvmesh,  &
                                    el%mesh_ref_array, ksint, idc, widc)

--- a/src/misc.f90
+++ b/src/misc.f90
@@ -785,7 +785,7 @@ contains
     real(r64),    allocatable :: weights_reduce(:,:)[:]
 
     integer(i64) :: iq, r0(3), r1(3), q(3), ipol, mode, chunk, num_active_images, count
-    integer(i64) :: i000, i100, i010, i110, i001, i101, i011, i111, equalpol, nq
+    integer(i64) :: equalpol, nq
     real(r64) :: x0, x1, y0, y1, z0, z1, x, y, z, v(2), v0(2), v1(2)
 
 
@@ -940,12 +940,12 @@ contains
     !! f The coarse mesh function to be interpolated.
     !! interpolation The result
 
-    integer(k8), intent(in) :: idc(:)
-    real(dp), intent(in) :: widc(:), f(:,:)
-    real(dp), intent(out) :: interpolation(:)
+    integer(i64), intent(in) :: idc(:)
+    real(r64), intent(in) :: widc(:), f(:,:)
+    real(r64), intent(out) :: interpolation(:)
 
 
-    real(dp) :: c00(size(f,2)), c01(size(f,2)), c10(size(f,2)), &
+    real(r64) :: c00(size(f,2)), c01(size(f,2)), c10(size(f,2)), &
                 c11(size(f,2)), c0(size(f,2)), c1(size(f,2))
 
     select case(idc(1))
@@ -969,7 +969,7 @@ contains
       interpolation = f(idc(2),:)
     case default
       call exit_with_message("Can't find point to interpolate on. Exiting.")
-    end case
+    end select
 
   end subroutine interpolate_using_precomputed
 


### PR DESCRIPTION
Dear Nakib,

I've changed the interpolation routine within the computation of the phonon drag contribution, so that the corners and the weights are precomputed, which prevents successive recomputation for the same point (misc.f90: precompute_interpolation_corners_and_weights). Moreover, I've removed the LAPACK algorithm and worked out the successive linear interpolations as well as allowed for N simultaneous interpolations, so the precomputed weights and corners ids can be used (misc.f90: interpolate_using_precomputed). In this last, there is the caveat of an array slicing when calling interpolate_using_precomputed, as I am calling it with response_ph(:, s, :); and might be not the best slicing especially if computed in each successive call. How is the memory here for non-toy problem in this point of the code? because it might be worth trying a reorder moving bands to first index.

I did a fast test on toy problem with Si ([input.nml](https://github.com/nakib/elphbolt/files/11685629/input.zip)), with old ([old.log](https://github.com/nakib/elphbolt/files/11685928/old.log)) and the new version ([new.log](https://github.com/nakib/elphbolt/files/11685742/new.log)); and I've found a speed-up of 1.85 in the whole execution time of the code and 7 in the coupled iterative part of the code. My guess it is that as the number of calls to the interpolation routine increases, it becomes much worthier to precompute the corners-id and the weights.

I see that the interpolation routine is used for 4ph, do you feel worth moving those also to that scheme?

Best regards,

Martí