### PR TITLE
Gamma point is properly treated

### DIFF
--- a/src/phonon.f90
+++ b/src/phonon.f90
@@ -1562,6 +1562,11 @@ contains
        call zheev("V", "U", self%numbands, dyn_total, self%numbands, omega2, &
             work, nwork, rwork, i)
 
+       !Fix gauge
+       if(abs(dyn_total(1, 1)) /= 0.0_r64) then
+          dyn_total(:, :) = dyn_total(:, :)/(dyn_total(1, 1)/abs(dyn_total(1, 1)))
+       end if
+
        ! Eigenvectors are also returned if required.
        if(present(eigenvect)) then
           eigenvect(iq, :, :) = transpose(dyn_total)
@@ -1578,6 +1583,13 @@ contains
           end do
           velocities(iq, i, :) = velocities(iq, i, :)/(2.0_r64*omegas(iq, i))
        end do
+
+       !Take care of gamma point.
+       if(all(qpoints(iq, 1:3) == 0)) then
+          omegas(iq, 1:3) = 0.0_r64
+          if(present(velocities)) velocities(iq, :, :) = 0.0_r64
+       end if
+
     end do
 
     !Units conversion


### PR DESCRIPTION
Gamma point in the Phonopy parser is properly set to 0 for acoustic modes, as well as the velocities. Not doing so leads to an spurious coupling with acoustic modes as Gamma as the discarding condition en1*en2*en3 == 0 in the interaction routines is never satisfied. This artificial coupling prevents convergence (see comparison: LOG_old.txt vs LOG_new.txt).
[LOG_new.txt](https://github.com/user-attachments/files/21862431/LOG_new.txt)
[LOG_old.txt](https://github.com/user-attachments/files/21862433/LOG_old.txt)
